### PR TITLE
ホームのユーザーリスト表示バグ改修

### DIFF
--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -139,7 +139,8 @@ const Home: React.FC = () => {
                             {users.map((user, index) => (
                                 <Grid item xs={12} sm={6} md={4} lg={3} key={index}>
                                     {user.roles?.length > 0 && 
-                                    user.roles[0]?.role === "creator" && user.userId !== cookies.user.uid && (
+                                    user.roles[0]?.role === "creator" && 
+                                    (cookies.user ? user.userId !== cookies.user.uid : true) && (
                                         <UserCard
                                         users={user}
                                         onClick={() => handleUserClick(user)}
@@ -167,7 +168,7 @@ const Home: React.FC = () => {
                             {users.map((user, index) => (
                                 <Grid item xs={12} sm={6} md={4} lg={3} key={index}>
                                     {user.roles?.length > 0 && 
-                                    user.roles[0]?.role === "artist" && user.userId !== cookies.user.uid && (
+                                    user.roles[0]?.role === "artist" && (cookies.user ? user.userId !== cookies.user.uid : true) && (
                                         <UserCard
                                         users={user}
                                         onClick={() => handleUserClick(user)}


### PR DESCRIPTION
- ログインなしユーザーでホームへアクセスした際に、ユーザーリストが表示されないため、改修